### PR TITLE
release:@react-native-oh-library/react-native-tab-view@3.5.2-0.1.3

### DIFF
--- a/packages/react-native-tab-view/package.json
+++ b/packages/react-native-tab-view/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@react-native-oh-tpl/react-native-tab-view",
   "description": "Tab view component for React Native",
-  "version": "3.5.2-0.1.2",
+  "version": "3.5.2-0.1.3",
   "keywords": [
     "react-native-component",
     "react-component",
@@ -51,7 +51,7 @@
     "use-latest-callback": "^0.1.5"
   },
   "devDependencies": {
-    "@react-native-oh-tpl/react-native-pager-view": "*",
+    "@react-native-oh-tpl/react-native-pager-view": "^6.2.3-0.1.8",
     "@types/react": "^18.2.39",
     "del-cli": "^5.0.0",
     "react": "18.2.0",


### PR DESCRIPTION
fix(pager-view依赖修改): 修复因pager-view版本问题导致的过渡动画失效问题，升级了pager-view版本号。