### PR TITLE
fix: 修复因useNativeDriver为false导致多tab切换动画不流畅问题

### DIFF
--- a/packages/react-native-tab-view/src/PagerViewAdapter.harmony.tsx
+++ b/packages/react-native-tab-view/src/PagerViewAdapter.harmony.tsx
@@ -157,7 +157,7 @@ export function PagerViewAdapter<T extends Route>({
               },
             },
           ],
-          { useNativeDriver: false }
+          { useNativeDriver: true }
         )}
         onPageSelected={(e) => {
           const index = e.nativeEvent.position;

--- a/packages/react-native-tab-view/src/PanResponderAdapter.tsx
+++ b/packages/react-native-tab-view/src/PanResponderAdapter.tsx
@@ -88,7 +88,7 @@ export function PanResponderAdapter<T extends Route>({
           timing(panX, {
             ...transitionConfig,
             toValue: offset,
-            useNativeDriver: false,
+            useNativeDriver: true,
           }),
         ]).start(({ finished }) => {
           if (finished) {


### PR DESCRIPTION


# Summary

fix: 修复因useNativeDriver为false导致多tab切换动画不流畅问题
close: #29 

## Test Plan
多tab页面，点击tab按钮，查看动画是否流畅

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)
