### PR TITLE
修复开启无障碍时屏幕朗读无法选中导航条按钮bug

### DIFF
--- a/packages/stack/src/views/Header/HeaderContainer.tsx
+++ b/packages/stack/src/views/Header/HeaderContainer.tsx
@@ -63,11 +63,12 @@ export default function HeaderContainer({
           headerStyleInterpolator,
         } = scene.descriptor.options;
 
-        if (headerMode !== mode || !headerShown) {
+        if ((headerMode !== mode || !headerShown) && focusedRoute.key !== scene.descriptor.route.key) {
           return null;
         }
 
         const isFocused = focusedRoute.key === scene.descriptor.route.key;
+        const shouldHideHeader = (headerMode !== mode || !headerShown) && isFocused;
         const previousScene = getPreviousScene({
           route: scene.descriptor.route,
         });
@@ -154,17 +155,14 @@ export default function HeaderContainer({
                     : undefined
                 }
                 pointerEvents={isFocused ? 'box-none' : 'none'}
-                accessibilityElementsHidden={!isFocused}
+                accessibilityElementsHidden={!isFocused || shouldHideHeader}
                 importantForAccessibility={
-                  isFocused ? 'auto' : 'no-hide-descendants'
+                  (isFocused && !shouldHideHeader) ? 'auto' : 'no-hide-descendants'
                 }
-                style={
-                  // Avoid positioning the focused header absolutely
-                  // Otherwise accessibility tools don't seem to be able to find it
-                  (mode === 'float' && !isFocused) || headerTransparent
-                    ? styles.header
-                    : null
-                }
+                style={[
+                  ((mode === 'float' && !isFocused) || headerTransparent) ? styles.header : null,
+                  shouldHideHeader ? { opacity: 0, height: 0, overflow: 'hidden' } : null
+                ]}
               >
                 {header !== undefined ? header(props) : <Header {...props} />}
               </View>

--- a/packages/stack/src/views/Header/HeaderContainer.tsx
+++ b/packages/stack/src/views/Header/HeaderContainer.tsx
@@ -6,7 +6,7 @@ import {
   Route,
 } from '@react-navigation/native';
 import * as React from 'react';
-import { Animated, StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
+import { Animated, StyleProp, StyleSheet, View, ViewStyle, Platform } from 'react-native';
 
 import {
   forNoAnimation,
@@ -36,6 +36,18 @@ export type Props = {
   style?: Animated.WithAnimatedValue<StyleProp<ViewStyle>>;
 };
 
+function compareVersion(v1: string, v2: string) {
+  const a = v1.split('.').map(Number);
+  const b = v2.split('.').map(Number);
+  for (let i = 0; i < Math.max(a.length, b.length); i++) {
+    const num1 = a[i] || 0;
+    const num2 = b[i] || 0;
+    if (num1 > num2) return 1;
+    if (num1 < num2) return -1;
+  }
+  return 0;
+}
+
 export default function HeaderContainer({
   mode,
   scenes,
@@ -63,12 +75,18 @@ export default function HeaderContainer({
           headerStyleInterpolator,
         } = scene.descriptor.options;
 
-        if ((headerMode !== mode || !headerShown) && focusedRoute.key !== scene.descriptor.route.key) {
+        const rawVersion = typeof Platform.Version === 'string' ? Platform.Version : String(Platform.Version);
+        const match = rawVersion.match(/(\d+\.\d+\.\d+)/);
+        const version = match ? match[1] : '0.0.0';
+        const isHarmony = (Platform.OS as string) === 'harmony';
+
+        let shouldHideHeader = isHarmony && compareVersion(version, '6.0.0') >= 0 ? !headerShown && focusedRoute.key !== scene.descriptor.route.key : headerMode !== mode || !headerShown;
+
+        if (shouldHideHeader) {
           return null;
         }
 
         const isFocused = focusedRoute.key === scene.descriptor.route.key;
-        const shouldHideHeader = (headerMode !== mode || !headerShown) && isFocused;
         const previousScene = getPreviousScene({
           route: scene.descriptor.route,
         });
@@ -155,14 +173,17 @@ export default function HeaderContainer({
                     : undefined
                 }
                 pointerEvents={isFocused ? 'box-none' : 'none'}
-                accessibilityElementsHidden={!isFocused || shouldHideHeader}
+                accessibilityElementsHidden={!isFocused}
                 importantForAccessibility={
-                  (isFocused && !shouldHideHeader) ? 'auto' : 'no-hide-descendants'
+                  isFocused ? 'auto' : 'no-hide-descendants'
                 }
-                style={[
-                  ((mode === 'float' && !isFocused) || headerTransparent) ? styles.header : null,
-                  shouldHideHeader ? { opacity: 0, height: 0, overflow: 'hidden' } : null
-                ]}
+                style={
+                  // Avoid positioning the focused header absolutely
+                  // Otherwise accessibility tools don't seem to be able to find it
+                  (mode === 'float' && !isFocused) || headerTransparent
+                    ? styles.header
+                    : null
+                }
               >
                 {header !== undefined ? header(props) : <Header {...props} />}
               </View>


### PR DESCRIPTION

## 1. 这个 PR 解决了哪些 issues？请标记这些 issues，以便合并 PR 后这些 issues 将会被自动关闭。
https://github.com/react-native-oh-library/react-navigation/issues/48
## 2. 这个功能是什么？（如果适用）
修复开启无障碍的屏幕朗读功能时，无法选中导航条上的返回按钮。

## 3. 您是如何实现解决方案的？
在鸿蒙 6.0.0 及以上版本中，无障碍（屏幕朗读）机制发生了变化。如果使用 `headerMode !== mode || !headerShown` 的判断逻辑，会导致当前聚焦页面的 header 被隐藏，进而使无障碍功能无法选中 header 内的图片、按钮等元素。

该问题具体表现为：
1. **错误逻辑的影响**：原有判断条件会导致所有 `headerShown: false` 的页面都不渲染 header，无论该页面是否为当前聚焦页面。
2. **鸿蒙 6.0.0+ 的特殊性**：在这些版本中，聚焦页面的 header 必须渲染，否则无障碍功能将无法正常朗读和操作 header 内的元素。
3. **版本差异**：
   - 鸿蒙 6.0.0 以下版本的无障碍机制与安卓类似，即使 header 未渲染，也不会影响聚焦页面的无障碍朗读功能，页面元素仍可被正常选中。因此旧版本可直接使用 `headerMode !== mode || !headerShown` 的判断逻辑。
   - 鸿蒙 6.0.0 及以上版本需要使用 `!headerShown && focusedRoute.key !== scene.descriptor.route.key` 的判断逻辑。

**修正方案说明**：
- `!headerShown`：表示 header 配置为隐藏。
- `focusedRoute.key !== scene.descriptor.route.key`：表示当前页面不是聚焦页面。
- **逻辑关系**：只有当 header 配置为隐藏 **且** 当前页面不是聚焦页面时，才不渲染 header。对于聚焦页面，即使 `headerShown` 设为 false，也必须渲染 header，以确保无障碍功能可以正常操作 header 内的元素。