### PR TITLE
feat: [#52]新增react-navigation-tabs库

### DIFF
--- a/OAT.xml
+++ b/OAT.xml
@@ -167,6 +167,16 @@
                 <filteritem type="filepath" name="packages/stack/src/types.tsx" desc="示例工程资源文件，不添加许可证头"/>
                 <filteritem type="filepath" name="packages/stack/src/utils/getDistanceForDirection.tsx" desc="示例工程资源文件，不添加许可证头"/>
                 <filteritem type="filepath" name="packages/stack/src/views/Header/HeaderSegment.tsx" desc="示例工程资源文件，不添加许可证头"/>
+                <filteritem type="filepath" name="packages/react-navigation-tabs/src/index.tsx" desc="示例工程资源文件，不添加许可证头"/>
+                <filteritem type="filepath" name="packages/react-navigation-tabs/src/types.tsx" desc="示例工程资源文件，不添加许可证头"/>
+                <filteritem type="filepath" name="packages/react-navigation-tabs/src/views/BottomTabBar.tsx" desc="示例工程资源文件，不添加许可证头"/>
+                <filteritem type="filepath" name="packages/react-navigation-tabs/src/views/CrossFadeIcon.tsx" desc="示例工程资源文件，不添加许可证头"/>
+                <filteritem type="filepath" name="packages/react-navigation-tabs/src/views/MaterialTopTabBar.tsx" desc="示例工程资源文件，不添加许可证头"/>
+                <filteritem type="filepath" name="packages/react-navigation-tabs/src/views/ResourceSavingScene.tsx" desc="示例工程资源文件，不添加许可证头"/>
+                <filteritem type="filepath" name="packages/react-navigation-tabs/src/utils/createTabNavigator.tsx" desc="示例工程资源文件，不添加许可证头"/>
+                <filteritem type="filepath" name="packages/react-navigation-tabs/src/utils/withDimensions.tsx" desc="示例工程资源文件，不添加许可证头"/>
+                <filteritem type="filepath" name="packages/react-navigation-tabs/src/navigators/createBottomTabNavigator.tsx" desc="示例工程资源文件，不添加许可证头"/>
+                <filteritem type="filepath" name="packages/react-navigation-tabs/src/navigators/createMaterialTopTabNavigator.tsx" desc="示例工程资源文件，不添加许可证头"/>
             </filefilter>
             <filefilter name="binaryFileTypePolicyFilter" desc="Filters for copyright header policies">
                 <filteritem type="filepath" name="packages/elements/src/assets/.*" desc="样式图片，不添加许可证头"/>
@@ -294,6 +304,16 @@
                 <filteritem type="filepath" name="packages/stack/src/types.tsx" desc="示例工程资源文件，不添加许可证头"/>
                 <filteritem type="filepath" name="packages/stack/src/utils/getDistanceForDirection.tsx" desc="示例工程资源文件，不添加许可证头"/>
                 <filteritem type="filepath" name="packages/stack/src/views/Header/HeaderSegment.tsx" desc="示例工程资源文件，不添加许可证头"/>
+                <filteritem type="filepath" name="packages/react-navigation-tabs/src/index.tsx" desc="示例工程资源文件，不添加许可证头"/>
+                <filteritem type="filepath" name="packages/react-navigation-tabs/src/types.tsx" desc="示例工程资源文件，不添加许可证头"/>
+                <filteritem type="filepath" name="packages/react-navigation-tabs/src/views/BottomTabBar.tsx" desc="示例工程资源文件，不添加许可证头"/>
+                <filteritem type="filepath" name="packages/react-navigation-tabs/src/views/CrossFadeIcon.tsx" desc="示例工程资源文件，不添加许可证头"/>
+                <filteritem type="filepath" name="packages/react-navigation-tabs/src/views/MaterialTopTabBar.tsx" desc="示例工程资源文件，不添加许可证头"/>
+                <filteritem type="filepath" name="packages/react-navigation-tabs/src/views/ResourceSavingScene.tsx" desc="示例工程资源文件，不添加许可证头"/>
+                <filteritem type="filepath" name="packages/react-navigation-tabs/src/utils/createTabNavigator.tsx" desc="示例工程资源文件，不添加许可证头"/>
+                <filteritem type="filepath" name="packages/react-navigation-tabs/src/utils/withDimensions.tsx" desc="示例工程资源文件，不添加许可证头"/>
+                <filteritem type="filepath" name="packages/react-navigation-tabs/src/navigators/createBottomTabNavigator.tsx" desc="示例工程资源文件，不添加许可证头"/>
+                <filteritem type="filepath" name="packages/react-navigation-tabs/src/navigators/createMaterialTopTabNavigator.tsx" desc="示例工程资源文件，不添加许可证头"/>
             </filefilter>
         </filefilterlist>
     </oatconfig>

--- a/packages/react-navigation-tabs/LICENSE.md
+++ b/packages/react-navigation-tabs/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 React Native Community
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/react-navigation-tabs/README.md
+++ b/packages/react-navigation-tabs/README.md
@@ -1,6 +1,6 @@
 # @react-native-oh-tpl/react-navigation-tabs
 
-This project is based on [react-native-oh-library/react-navigation-tabs](https://github.com/react-navigation/react-navigation/tree/main/packages/react-navigation-tabs)
+This project is based on [react-navigation-tabs](https://github.com/react-navigation/tabs/tree/v2.7.0)
 
 ## Documentation
 

--- a/packages/react-navigation-tabs/README.md
+++ b/packages/react-navigation-tabs/README.md
@@ -1,0 +1,13 @@
+# @react-native-oh-tpl/react-navigation-tabs
+
+This project is based on [react-native-oh-library/react-navigation-tabs](https://github.com/react-navigation/react-navigation/tree/main/packages/react-navigation-tabs)
+
+## Documentation
+
+- [中文](https://gitee.com/react-native-oh-library/usage-docs/blob/master/zh-cn/react-navigation-tabs.md)
+
+- [English](https://gitee.com/react-native-oh-library/usage-docs/blob/master/en/react-navigation-tabs.md)
+
+## License
+
+This library is licensed under [The MIT License (MIT)](https://github.com/react-navigation/react-navigation/blob/main/packages/react-navigation-tabs/LICENSE)

--- a/packages/react-navigation-tabs/package.json
+++ b/packages/react-navigation-tabs/package.json
@@ -1,0 +1,122 @@
+{
+  "name": "@react-native-oh-tpl/react-navigation-tabs",
+  "version": "2.7.0-0.1.0",
+  "description": "Tab Navigation components for React Navigation",
+  "main": "lib/commonjs/index.js",
+  "module": "lib/module/index.js",
+  "react-native": "lib/module/index.js",
+  "types": "lib/typescript/src/index.d.ts",
+  "files": [
+    "src",
+    "lib",
+    "harmony"
+  ],
+  "scripts": {
+    "test": "jest",
+    "typescript": "tsc --noEmit",
+    "lint": "eslint --ext .js,.ts,.tsx .",
+    "bootstrap": "yarn --cwd example && yarn",
+    "example": "yarn --cwd example",
+    "release": "yarn release-it",
+    "prepare": "bob build"
+  },
+  "keywords": [
+    "react-native-component",
+    "react-component",
+    "react-native",
+    "ios",
+    "android",
+    "tab",
+    "swipe",
+    "scrollable",
+    "coverflow"
+  ],
+  "harmony": {
+    "alias": "react-navigation-tabs"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/react-native-oh-library/react-navigation.git",
+    "directory": "packages/react-navigation-tabs"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "bugs": {
+    "url": "https://github.com/react-native-oh-library/react-navigation/issues"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/react-navigation/tabs#readme",
+  "dependencies": {
+    "@types/node": "^12.12.0",
+    "hoist-non-react-statics": "^3.3.0",
+    "react-lifecycles-compat": "^3.0.4",
+    "react-native-safe-area-view": "^0.14.6"
+  },
+  "devDependencies": {
+    "@commitlint/config-conventional": "^7.5.0",
+    "@expo/vector-icons": "^10.0.1",
+    "@react-native-community/bob": "^0.6.1",
+    "@types/hoist-non-react-statics": "^3.3.1",
+    "@types/react": "^16.8.17",
+    "@types/react-native": "^0.57.57",
+    "babel-jest": "^24.5.0",
+    "commitlint": "^7.5.2",
+    "conventional-changelog-cli": "^2.0.12",
+    "enzyme": "3.9.0",
+    "enzyme-adapter-react-16": "^1.11.2",
+    "enzyme-to-json": "^3.2.2",
+    "eslint": "^6.5.1",
+    "eslint-config-satya164": "^3.1.2",
+    "eslint-plugin-react-native-globals": "^0.1.0",
+    "flow-bin": "~0.78.0",
+    "husky": "^1.3.1",
+    "jest": "^24.5.0",
+    "prettier": "^1.18.2",
+    "react": "16.5.0",
+    "react-dom": "16.5.0",
+    "react-native": "~0.57.1",
+    "@react-native-oh-tpl/react-native-gesture-handler": "2.14.17-rc.0",
+    "@react-native-oh-tpl/react-native-reanimated": "3.6.4-rc.1",
+    "@react-native-oh-tpl/react-native-tab-view": "^3.5.2-0.1.3",
+    "react-native-reanimated": "^1.2.0",
+    "react-native-screens": "3.29.0",
+    "react-navigation": "^4.0.7",
+    "react-test-renderer": "16.5.0",
+    "release-it": "^10.3.1",
+    "typescript": "^5.9.2"
+  },
+  "peerDependencies": {
+    "react": "*",
+    "react-native": "*"
+  },
+  "husky": {
+    "hooks": {
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
+      "pre-commit": "yarn lint && yarn flow check"
+    }
+  },
+  "jest": {
+    "preset": "react-native",
+    "setupFiles": [
+      "<rootDir>/__setup__/enzyme.js"
+    ],
+    "modulePathIgnorePatterns": [
+      "<rootDir>/example/node_modules",
+      "<rootDir>/lib/"
+    ],
+    "snapshotSerializers": [
+      "enzyme-to-json/serializer"
+    ]
+  },
+  "@react-native-community/bob": {
+    "source": "src",
+    "output": "lib",
+    "targets": [
+      "commonjs",
+      "module",
+      "typescript"
+    ]
+  }
+}

--- a/packages/react-navigation-tabs/src/index.tsx
+++ b/packages/react-navigation-tabs/src/index.tsx
@@ -1,0 +1,34 @@
+/**
+ * Navigators
+ */
+export {
+  default as createBottomTabNavigator,
+} from './navigators/createBottomTabNavigator';
+export {
+  default as createMaterialTopTabNavigator,
+} from './navigators/createMaterialTopTabNavigator';
+
+/**
+ * Views
+ */
+export { default as BottomTabBar } from './views/BottomTabBar';
+export { default as MaterialTopTabBar } from './views/MaterialTopTabBar';
+
+/**
+ * Utils
+ */
+export { default as createTabNavigator } from './utils/createTabNavigator';
+
+/**
+ * Types
+ */
+export {
+  BottomTabBarProps,
+  NavigationTabState,
+  NavigationTabProp,
+  NavigationTabScreenProps,
+  NavigationBottomTabOptions,
+  NavigationMaterialTabOptions,
+  NavigationBottomTabScreenComponent,
+  NavigationMaterialTabScreenComponent,
+} from './types';

--- a/packages/react-navigation-tabs/src/navigators/createBottomTabNavigator.tsx
+++ b/packages/react-navigation-tabs/src/navigators/createBottomTabNavigator.tsx
@@ -1,0 +1,185 @@
+import * as React from 'react';
+import {
+  View,
+  StyleSheet,
+  AccessibilityRole,
+  AccessibilityState,
+} from 'react-native';
+import { NavigationRoute } from 'react-navigation';
+
+// eslint-disable-next-line import/no-unresolved
+import { ScreenContainer } from 'react-native-screens';
+
+import createTabNavigator, {
+  NavigationViewProps,
+} from '../utils/createTabNavigator';
+import BottomTabBar from '../views/BottomTabBar';
+import ResourceSavingScene from '../views/ResourceSavingScene';
+import {
+  NavigationTabProp,
+  NavigationBottomTabOptions,
+  BottomTabBarOptions,
+  SceneDescriptorMap,
+} from '../types';
+
+type Config = {
+  lazy?: boolean;
+  tabBarComponent?: React.ComponentType<any>;
+  tabBarOptions?: BottomTabBarOptions;
+};
+
+type Props = NavigationViewProps &
+  Config & {
+    getAccessibilityRole: (props: {
+      route: NavigationRoute;
+    }) => AccessibilityRole | undefined;
+    getAccessibilityStates: (props: {
+      route: NavigationRoute;
+      focused: boolean;
+    }) => AccessibilityState[];
+    navigation: NavigationTabProp;
+    descriptors: SceneDescriptorMap;
+    screenProps?: unknown;
+  };
+
+type State = {
+  loaded: number[];
+};
+
+class TabNavigationView extends React.PureComponent<Props, State> {
+  static defaultProps = {
+    lazy: true,
+    getAccessibilityRole: (): AccessibilityRole => 'button',
+    getAccessibilityStates: ({
+      focused,
+    }: {
+      focused: boolean;
+    }): AccessibilityState[] => (focused ? ['selected'] : []),
+  };
+
+  static getDerivedStateFromProps(nextProps: Props, prevState: State) {
+    const { index } = nextProps.navigation.state;
+
+    return {
+      // Set the current tab to be loaded if it was not loaded before
+      loaded: prevState.loaded.includes(index)
+        ? prevState.loaded
+        : [...prevState.loaded, index],
+    };
+  }
+
+  state = {
+    loaded: [this.props.navigation.state.index],
+  };
+
+  _getButtonComponent = ({ route }: { route: NavigationRoute }) => {
+    const { descriptors } = this.props;
+    const descriptor = descriptors[route.key];
+    const options = descriptor.options;
+
+    if (options.tabBarButtonComponent) {
+      return options.tabBarButtonComponent;
+    }
+
+    return undefined;
+  };
+
+  _renderTabBar = () => {
+    const {
+      tabBarComponent: TabBarComponent = BottomTabBar,
+      tabBarOptions,
+      navigation,
+      screenProps,
+      getLabelText,
+      getAccessibilityLabel,
+      getAccessibilityRole,
+      getAccessibilityStates,
+      getTestID,
+      renderIcon,
+      onTabPress,
+      onTabLongPress,
+    } = this.props;
+
+    const { descriptors } = this.props;
+    const { state } = this.props.navigation;
+    const route = state.routes[state.index];
+    const descriptor = descriptors[route.key];
+    const options = descriptor.options;
+
+    if (options.tabBarVisible === false) {
+      return null;
+    }
+
+    return (
+      <TabBarComponent
+        {...tabBarOptions}
+        jumpTo={this._jumpTo}
+        navigation={navigation}
+        screenProps={screenProps}
+        onTabPress={onTabPress}
+        onTabLongPress={onTabLongPress}
+        getLabelText={getLabelText}
+        getButtonComponent={this._getButtonComponent}
+        getAccessibilityLabel={getAccessibilityLabel}
+        getAccessibilityRole={getAccessibilityRole}
+        getAccessibilityStates={getAccessibilityStates}
+        getTestID={getTestID}
+        renderIcon={renderIcon}
+      />
+    );
+  };
+
+  _jumpTo = (key: string) => {
+    const { navigation, onIndexChange } = this.props;
+
+    const index = navigation.state.routes.findIndex(route => route.key === key);
+
+    onIndexChange(index);
+  };
+
+  render() {
+    const { navigation, renderScene, lazy } = this.props;
+    const { routes } = navigation.state;
+    const { loaded } = this.state;
+
+    return (
+      <View style={styles.container}>
+        <ScreenContainer style={styles.pages}>
+          {routes.map((route, index) => {
+            if (lazy && !loaded.includes(index)) {
+              // Don't render a screen if we've never navigated to it
+              return null;
+            }
+
+            const isFocused = navigation.state.index === index;
+
+            return (
+              <ResourceSavingScene
+                key={route.key}
+                style={StyleSheet.absoluteFill}
+                isVisible={isFocused}
+              >
+                {renderScene({ route })}
+              </ResourceSavingScene>
+            );
+          })}
+        </ScreenContainer>
+        {this._renderTabBar()}
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    overflow: 'hidden',
+  },
+  pages: {
+    flex: 1,
+  },
+});
+
+export default createTabNavigator<Config, NavigationBottomTabOptions, Props>(
+  TabNavigationView
+);

--- a/packages/react-navigation-tabs/src/navigators/createMaterialTopTabNavigator.tsx
+++ b/packages/react-navigation-tabs/src/navigators/createMaterialTopTabNavigator.tsx
@@ -1,0 +1,142 @@
+import * as React from 'react';
+import { StyleProp, ViewStyle } from 'react-native';
+import { TabView, SceneRendererProps } from 'react-native-tab-view';
+import createTabNavigator, {
+  NavigationViewProps,
+} from '../utils/createTabNavigator';
+import MaterialTopTabBar from '../views/MaterialTopTabBar';
+import {
+  NavigationTabProp,
+  NavigationMaterialTabOptions,
+  MaterialTabBarOptions,
+  SceneDescriptorMap,
+} from '../types';
+
+type Route = {
+  key: string;
+  routeName: string;
+};
+
+type Config = {
+  keyboardDismissMode?: 'none' | 'on-drag';
+  swipeEnabled?: boolean;
+  swipeDistanceThreshold?: number;
+  swipeVelocityThreshold?: number;
+  initialLayout?: { width?: number; height?: number };
+  lazy?: boolean;
+  lazyPlaceholderComponent?: React.ComponentType<{ route: Route }>;
+  tabBarComponent?: React.ComponentType<any>;
+  tabBarOptions?: MaterialTabBarOptions;
+  tabBarPosition?: 'top' | 'bottom';
+  sceneContainerStyle?: StyleProp<ViewStyle>;
+  style?: StyleProp<ViewStyle>;
+};
+
+type Props = NavigationViewProps &
+  Config & {
+    onSwipeStart?: () => void;
+    onSwipeEnd?: () => void;
+    navigation: NavigationTabProp;
+    descriptors: SceneDescriptorMap;
+    screenProps?: unknown;
+  };
+
+class MaterialTabView extends React.PureComponent<Props> {
+  private renderTabBar = (props: SceneRendererProps) => {
+    const { state } = this.props.navigation;
+    const route = state.routes[state.index];
+    const { descriptors } = this.props;
+    const descriptor = descriptors[route.key];
+    const options = descriptor.options;
+
+    const tabBarVisible =
+      options.tabBarVisible == null ? true : options.tabBarVisible;
+
+    const {
+      navigation,
+      getLabelText,
+      getAccessibilityLabel,
+      getTestID,
+      renderIcon,
+      onTabPress,
+      onTabLongPress,
+      tabBarComponent: TabBarComponent = MaterialTopTabBar,
+      tabBarPosition,
+      tabBarOptions,
+      screenProps,
+    } = this.props;
+
+    if (TabBarComponent === null || !tabBarVisible) {
+      return null;
+    }
+
+    return (
+      <TabBarComponent
+        {...tabBarOptions}
+        {...props}
+        tabBarPosition={tabBarPosition}
+        screenProps={screenProps}
+        navigation={navigation}
+        getLabelText={getLabelText}
+        getAccessibilityLabel={getAccessibilityLabel}
+        getTestID={getTestID}
+        renderIcon={renderIcon}
+        onTabPress={onTabPress}
+        onTabLongPress={onTabLongPress}
+      />
+    );
+  };
+
+  render() {
+    const {
+      /* eslint-disable @typescript-eslint/no-unused-vars */
+      getLabelText,
+      getAccessibilityLabel,
+      getTestID,
+      renderIcon,
+      onTabPress,
+      onTabLongPress,
+      screenProps,
+      tabBarComponent,
+      tabBarOptions,
+      /* eslint-enable @typescript-eslint/no-unused-vars */
+      lazyPlaceholderComponent,
+      navigation,
+      descriptors,
+      ...rest
+    } = this.props;
+
+    const { state } = navigation;
+    const route = state.routes[state.index];
+    const descriptor = descriptors[route.key];
+    const options = descriptor.options;
+
+    let swipeEnabled =
+      // @ts-ignore
+      options.swipeEnabled == null
+        ? this.props.swipeEnabled
+        : (options as any).swipeEnabled;
+
+    if (typeof swipeEnabled === 'function') {
+      swipeEnabled = swipeEnabled(state);
+    }
+
+    return (
+      <TabView
+        {...rest}
+        navigationState={navigation.state}
+        swipeEnabled={swipeEnabled}
+        renderTabBar={this.renderTabBar}
+        renderLazyPlaceholder={
+          lazyPlaceholderComponent !== undefined
+            ? props => React.createElement(lazyPlaceholderComponent, props)
+            : undefined
+        }
+      />
+    );
+  }
+}
+
+export default createTabNavigator<Config, NavigationMaterialTabOptions, Props>(
+  MaterialTabView
+);

--- a/packages/react-navigation-tabs/src/types.tsx
+++ b/packages/react-navigation-tabs/src/types.tsx
@@ -1,0 +1,273 @@
+import * as React from 'react';
+import {
+  AccessibilityRole,
+  AccessibilityState,
+  StyleProp,
+  TextStyle,
+  ViewStyle,
+} from 'react-native';
+import SafeAreaView from 'react-native-safe-area-view';
+import Animated from '@react-native-oh-tpl/react-native-reanimated';
+import {
+  NavigationRoute,
+  NavigationState,
+  NavigationScreenProp,
+  NavigationParams,
+  NavigationDescriptor,
+  NavigationScreenConfig,
+  SupportedThemes,
+} from 'react-navigation';
+
+export type NavigationTabState = NavigationState;
+
+export type NavigationTabProp<
+  State = NavigationRoute,
+  Params = NavigationParams
+> = NavigationScreenProp<State, Params> & {
+  jumpTo(routeName: string, key?: string): void;
+};
+
+export type ThemedColor =
+  | string
+  | {
+      light: string;
+      dark: string;
+    };
+
+export type Orientation = 'horizontal' | 'vertical';
+
+export type LabelPosition = 'beside-icon' | 'below-icon';
+
+interface BaseAnimation {
+  useNativeDriver?: boolean;
+}
+interface TimingAnimation extends BaseAnimation {
+  easing?: (value: number) => number;
+  duration?: number;
+  delay?: number;
+}
+interface SpringAnimation extends BaseAnimation {
+  overshootClamping?: boolean;
+  restDisplacementThreshold?: number;
+  restSpeedThreshold?: number;
+  velocity?: number | { x: number; y: number };
+  bounciness?: number;
+  speed?: number;
+  tension?: number;
+  friction?: number;
+  stiffness?: number;
+  mass?: number;
+  damping?: number;
+  delay?: number;
+}
+export type TimingKeyboardAnimationConfig = {
+  animation: 'timing';
+  config?: TimingAnimation;
+};
+export type SpringKeyboardAnimationConfig = {
+  animation: 'spring';
+  config?: SpringAnimation;
+};
+export type KeyboardAnimationConfig =
+  | TimingKeyboardAnimationConfig
+  | SpringKeyboardAnimationConfig;
+export type KeyboardHidesTabBarAnimationConfig = {
+  show: KeyboardAnimationConfig;
+  hide: KeyboardAnimationConfig;
+};
+
+export type BottomTabBarOptions = {
+  keyboardHidesTabBar?: boolean;
+  keyboardHidesTabBarAnimationConfig?: Partial<
+    KeyboardHidesTabBarAnimationConfig
+  >;
+  activeTintColor?: ThemedColor;
+  inactiveTintColor?: ThemedColor;
+  activeBackgroundColor?: ThemedColor;
+  inactiveBackgroundColor?: ThemedColor;
+  allowFontScaling?: boolean;
+  showLabel?: boolean;
+  showIcon?: boolean;
+  labelStyle?: StyleProp<TextStyle>;
+  tabStyle?: StyleProp<ViewStyle>;
+  labelPosition?:
+    | LabelPosition
+    | ((options: { deviceOrientation: Orientation }) => LabelPosition);
+  adaptive?: boolean;
+  safeAreaInset?: React.ComponentProps<typeof SafeAreaView>['forceInset'];
+  style?: StyleProp<ViewStyle>;
+};
+
+export type ButtonComponentProps = {
+  route: NavigationRoute;
+  focused: boolean;
+  onPress: () => void;
+  onLongPress: () => void;
+  testID?: string;
+  accessibilityLabel?: string;
+  accessibilityRole?: AccessibilityRole;
+  accessibilityStates?: AccessibilityState[];
+  style?: StyleProp<ViewStyle>;
+};
+
+export type BottomTabBarProps = BottomTabBarOptions & {
+  navigation: NavigationTabProp;
+  onTabPress: (props: { route: NavigationRoute }) => void;
+  onTabLongPress: (props: { route: NavigationRoute }) => void;
+  getAccessibilityLabel: (props: {
+    route: NavigationRoute;
+  }) => string | undefined;
+  getAccessibilityRole: (props: {
+    route: NavigationRoute;
+  }) => AccessibilityRole | undefined;
+  getAccessibilityStates: (props: {
+    route: NavigationRoute;
+    focused: boolean;
+  }) => AccessibilityState[];
+  getButtonComponent: (props: {
+    route: NavigationRoute;
+  }) => React.ComponentType<ButtonComponentProps> | undefined;
+  getLabelText: (props: {
+    route: NavigationRoute;
+  }) =>
+    | ((scene: {
+        focused: boolean;
+        tintColor?: string;
+        orientation?: 'horizontal' | 'vertical';
+      }) => string | undefined)
+    | string
+    | undefined;
+  getTestID: (props: { route: NavigationRoute }) => string | undefined;
+  renderIcon: (props: {
+    route: NavigationRoute;
+    focused: boolean;
+    tintColor?: string;
+    horizontal?: boolean;
+  }) => React.ReactNode;
+  dimensions: { width: number; height: number };
+  isLandscape: boolean;
+  jumpTo: (key: string) => void;
+  screenProps: unknown;
+};
+
+export type MaterialTabBarOptions = {
+  activeTintColor?: string;
+  allowFontScaling?: boolean;
+  bounces?: boolean;
+  inactiveTintColor?: string;
+  pressColor?: string;
+  pressOpacity?: number;
+  scrollEnabled?: boolean;
+  showIcon?: boolean;
+  showLabel?: boolean;
+  upperCaseLabel?: boolean;
+  tabStyle?: StyleProp<ViewStyle>;
+  indicatorStyle?: StyleProp<ViewStyle>;
+  iconStyle?: StyleProp<ViewStyle>;
+  labelStyle?: StyleProp<TextStyle>;
+  contentContainerStyle?: StyleProp<ViewStyle>;
+  style?: StyleProp<ViewStyle>;
+};
+
+export type MaterialTabBarProps = MaterialTabBarOptions & {
+  layout: {
+    width: number;
+    height: number;
+  };
+  position: Animated.SharedValue<number>;
+  jumpTo: (key: string) => void;
+  getLabelText: (scene: {
+    route: NavigationRoute;
+  }) =>
+    | ((scene: { focused: boolean; tintColor: string }) => string | undefined)
+    | string
+    | undefined;
+  getAccessible?: (scene: { route: NavigationRoute }) => boolean | undefined;
+  getAccessibilityLabel: (scene: {
+    route: NavigationRoute;
+  }) => string | undefined;
+  getTestID: (scene: { route: NavigationRoute }) => string | undefined;
+  renderIcon: (scene: {
+    route: NavigationRoute;
+    focused: boolean;
+    tintColor: string;
+    horizontal?: boolean;
+  }) => React.ReactNode;
+  renderBadge?: (scene: { route: NavigationRoute }) => React.ReactNode;
+  onTabPress?: (scene: { route: NavigationRoute }) => void;
+  onTabLongPress?: (scene: { route: NavigationRoute }) => void;
+  tabBarPosition?: 'top' | 'bottom';
+  screenProps: unknown;
+  navigation: NavigationTabProp;
+};
+
+export type NavigationCommonTabOptions = {
+  title?: string;
+  tabBarLabel?: React.ReactNode;
+  tabBarVisible?: boolean;
+  tabBarAccessibilityLabel?: string;
+  tabBarTestID?: string;
+  tabBarIcon?:
+    | React.ReactNode
+    | ((props: {
+        focused: boolean;
+        tintColor?: string;
+        horizontal?: boolean;
+      }) => React.ReactNode);
+  tabBarOnPress?: (props: {
+    navigation: NavigationTabProp;
+    defaultHandler: () => void;
+  }) => void;
+  tabBarOnLongPress?: (props: {
+    navigation: NavigationTabProp;
+    defaultHandler: () => void;
+  }) => void;
+};
+
+export type NavigationBottomTabOptions = NavigationCommonTabOptions & {
+  tabBarButtonComponent?: React.ComponentType<ButtonComponentProps>;
+};
+
+export type NavigationMaterialTabOptions = NavigationCommonTabOptions & {
+  tabBarButtonComponent?: React.ComponentType<any>;
+  swipeEnabled?: boolean | ((state: NavigationState) => boolean);
+};
+
+export type NavigationTabScreenProps<
+  Params = NavigationParams,
+  ScreenProps = unknown
+> = {
+  theme: SupportedThemes;
+  navigation: NavigationTabProp<NavigationRoute, Params>;
+  screenProps: ScreenProps;
+};
+
+export type NavigationMaterialTabScreenComponent<
+  Params = NavigationParams,
+  ScreenProps = unknown
+> = React.ComponentType<NavigationTabScreenProps<Params, ScreenProps>> & {
+  navigationOptions?: NavigationScreenConfig<
+    NavigationMaterialTabOptions,
+    NavigationTabProp<NavigationRoute, Params>,
+    ScreenProps
+  >;
+};
+
+export type NavigationBottomTabScreenComponent<
+  Params = NavigationParams,
+  ScreenProps = unknown
+> = React.ComponentType<NavigationTabScreenProps<Params, ScreenProps>> & {
+  navigationOptions?: NavigationScreenConfig<
+    NavigationBottomTabOptions,
+    NavigationTabProp<NavigationRoute, Params>,
+    ScreenProps
+  >;
+};
+
+export type SceneDescriptorMap = {
+  [key: string]: NavigationDescriptor<
+    NavigationParams,
+    NavigationBottomTabOptions | NavigationMaterialTabOptions,
+    NavigationTabProp
+  >;
+};

--- a/packages/react-navigation-tabs/src/utils/createTabNavigator.tsx
+++ b/packages/react-navigation-tabs/src/utils/createTabNavigator.tsx
@@ -1,0 +1,259 @@
+import * as React from 'react';
+import {
+  TabRouter,
+  StackActions,
+  SceneView,
+  createNavigator,
+  SwitchActions,
+  NavigationRoute,
+  NavigationRouteConfigMap,
+  CreateNavigatorConfig,
+  NavigationTabRouterConfig,
+} from 'react-navigation';
+import {
+  NavigationTabProp,
+  NavigationCommonTabOptions,
+  SceneDescriptorMap,
+} from '../types';
+
+type RouteConfig<Options> = NavigationRouteConfigMap<
+  Options,
+  NavigationTabProp<NavigationRoute, any>
+>;
+
+type CommonProps = {
+  navigation: NavigationTabProp;
+  descriptors: SceneDescriptorMap;
+  screenProps?: unknown;
+};
+
+type ExtraProps<Config extends {}> = {
+  navigationConfig: Config;
+};
+
+export type RenderIconProps = {
+  route: NavigationRoute;
+  focused: boolean;
+  tintColor?: string;
+  horizontal?: boolean;
+};
+
+export type NavigationViewProps = {
+  getLabelText: (props: { route: NavigationRoute }) => string | undefined;
+  getAccessibilityLabel: (props: {
+    route: NavigationRoute;
+  }) => string | undefined;
+  getTestID: (props: { route: NavigationRoute }) => string | undefined;
+  renderIcon: (props: RenderIconProps) => React.ReactNode;
+  renderScene: (props: { route: NavigationRoute }) => React.ReactNode;
+  onIndexChange: (index: number) => void;
+  onTabPress: (props: { route: NavigationRoute }) => void;
+  onTabLongPress: (props: { route: NavigationRoute }) => void;
+};
+
+export default function createTabNavigator<
+  Config extends {},
+  Options extends NavigationCommonTabOptions,
+  Props extends NavigationViewProps & CommonProps
+>(TabView: React.ComponentType<Props & Config & Options>) {
+  class NavigationView extends React.Component<
+    Exclude<Props, NavigationViewProps> & ExtraProps<Config>
+  > {
+    _renderScene = ({ route }: { route: { key: string } }) => {
+      const { screenProps, descriptors } = this.props;
+      const descriptor = descriptors[route.key];
+      const TabComponent = descriptor.getComponent();
+      return (
+        <SceneView
+          screenProps={screenProps}
+          navigation={descriptor.navigation}
+          component={TabComponent}
+        />
+      );
+    };
+
+    _renderIcon = ({
+      route,
+      focused,
+      tintColor,
+      horizontal = false,
+    }: RenderIconProps) => {
+      const { descriptors } = this.props;
+      const descriptor = descriptors[route.key];
+      const options = descriptor.options;
+
+      if (options.tabBarIcon) {
+        return typeof options.tabBarIcon === 'function'
+          ? options.tabBarIcon({ focused, tintColor, horizontal })
+          : options.tabBarIcon;
+      }
+
+      return null;
+    };
+
+    _getLabelText = ({ route }: { route: NavigationRoute }) => {
+      const { descriptors } = this.props;
+      const descriptor = descriptors[route.key];
+      const options = descriptor.options;
+
+      if (options.tabBarLabel) {
+        return options.tabBarLabel;
+      }
+
+      if (typeof options.title === 'string') {
+        return options.title;
+      }
+
+      return route.routeName;
+    };
+
+    _getAccessibilityLabel = ({ route }: { route: NavigationRoute }) => {
+      const { descriptors } = this.props;
+      const descriptor = descriptors[route.key];
+      const options = descriptor.options;
+
+      if (typeof options.tabBarAccessibilityLabel !== 'undefined') {
+        return options.tabBarAccessibilityLabel;
+      }
+
+      const label = this._getLabelText({ route });
+
+      if (typeof label === 'string') {
+        const { routes } = this.props.navigation.state;
+        return `${label}, tab, ${routes.indexOf(route) + 1} of ${
+          routes.length
+        }`;
+      }
+
+      return undefined;
+    };
+
+    _getTestID = ({ route }: { route: NavigationRoute }) => {
+      const { descriptors } = this.props;
+      const descriptor = descriptors[route.key];
+      const options = descriptor.options;
+
+      return options.tabBarTestID;
+    };
+
+    _makeDefaultHandler = ({
+      route,
+      navigation,
+    }: {
+      route: NavigationRoute;
+      navigation: NavigationTabProp;
+    }) => () => {
+      if (navigation.isFocused()) {
+        if (route.hasOwnProperty('index') && route.index > 0) {
+          // If current tab has a nested navigator, pop to top
+          navigation.dispatch(StackActions.popToTop({ key: route.key }));
+        } else {
+          navigation.emit('refocus');
+        }
+      } else {
+        this._jumpTo(route.routeName);
+      }
+    };
+
+    _handleTabPress = ({ route }: { route: NavigationRoute }) => {
+      this._isTabPress = true;
+
+      // After tab press, handleIndexChange will be called synchronously
+      // So we reset it in promise callback
+      Promise.resolve().then(() => (this._isTabPress = false));
+
+      const { descriptors } = this.props;
+      const descriptor = descriptors[route.key];
+      const { navigation, options } = descriptor;
+      const defaultHandler = this._makeDefaultHandler({ route, navigation });
+
+      if (options.tabBarOnPress) {
+        options.tabBarOnPress({ navigation, defaultHandler });
+      } else {
+        defaultHandler();
+      }
+    };
+
+    _handleTabLongPress = ({ route }: { route: NavigationRoute }) => {
+      const { descriptors } = this.props;
+      const descriptor = descriptors[route.key];
+      const { navigation, options } = descriptor;
+
+      const defaultHandler = this._makeDefaultHandler({ route, navigation });
+
+      if (options.tabBarOnLongPress) {
+        options.tabBarOnLongPress({ navigation, defaultHandler });
+      } else {
+        defaultHandler();
+      }
+    };
+
+    _handleIndexChange = (index: number) => {
+      if (this._isTabPress) {
+        this._isTabPress = false;
+        return;
+      }
+
+      this._jumpTo(this.props.navigation.state.routes[index].routeName);
+    };
+
+    _jumpTo = (routeName: string) => {
+      const { navigation } = this.props;
+
+      navigation.dispatch(
+        SwitchActions.jumpTo({
+          routeName,
+          key: navigation.state.key,
+        })
+      );
+    };
+
+    _isTabPress: boolean = false;
+
+    render() {
+      const {
+        descriptors,
+        navigation,
+        screenProps,
+        navigationConfig,
+      } = this.props;
+      const { state } = navigation;
+      const route = state.routes[state.index];
+      const descriptor = descriptors[route.key];
+
+      return (
+        // TODO: don't have time to fix it right now
+        // @ts-ignore
+        <TabView
+          {...navigationConfig}
+          {...descriptor.options}
+          getLabelText={this._getLabelText}
+          getAccessibilityLabel={this._getAccessibilityLabel}
+          getTestID={this._getTestID}
+          renderIcon={this._renderIcon}
+          renderScene={this._renderScene}
+          onIndexChange={this._handleIndexChange}
+          onTabPress={this._handleTabPress}
+          onTabLongPress={this._handleTabLongPress}
+          navigation={navigation}
+          descriptors={descriptors}
+          screenProps={screenProps}
+        />
+      );
+    }
+  }
+
+  return (
+    routes: RouteConfig<Options>,
+    config: CreateNavigatorConfig<
+      Partial<Config>,
+      NavigationTabRouterConfig,
+      Partial<Options>,
+      NavigationTabProp<NavigationRoute, any>
+    > = {}
+  ) => {
+    const router = TabRouter(routes, config as any);
+
+    return createNavigator(NavigationView as any, router, config as any);
+  };
+}

--- a/packages/react-navigation-tabs/src/utils/withDimensions.tsx
+++ b/packages/react-navigation-tabs/src/utils/withDimensions.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import { Dimensions, ScaledSize } from 'react-native';
+import hoistNonReactStatic from 'hoist-non-react-statics';
+
+type DimensionsType = {
+  width: number;
+  height: number;
+};
+
+type InjectedProps = {
+  dimensions: DimensionsType;
+  isLandscape: boolean;
+};
+
+export const isOrientationLandscape = ({ width, height }: DimensionsType) =>
+  width > height;
+
+export default function withDimensions<Props extends InjectedProps>(
+  WrappedComponent: React.ComponentType<Props>
+): React.ComponentType<Pick<Props, Exclude<keyof Props, keyof InjectedProps>>> {
+  class EnhancedComponent extends React.Component {
+    static displayName = `withDimensions(${WrappedComponent.displayName})`;
+
+    constructor(props: Props) {
+      super(props);
+
+      const { width, height } = Dimensions.get('window');
+      this.state = {
+        dimensions: { width, height },
+        isLandscape: isOrientationLandscape({ width, height }),
+      };
+    }
+
+    componentDidMount() {
+      Dimensions.addEventListener('change', this.handleOrientationChange);
+    }
+
+    handleOrientationChange = ({ window }: { window: ScaledSize }) => {
+      const { width, height } = window;
+      this.setState({
+        dimensions: { width, height },
+        isLandscape: isOrientationLandscape({ width, height }),
+      });
+    };
+
+    render() {
+      // @ts-ignore
+      return <WrappedComponent {...this.props} {...this.state} />;
+    }
+  }
+
+  // @ts-ignore
+  return hoistNonReactStatic(EnhancedComponent, WrappedComponent);
+}

--- a/packages/react-navigation-tabs/src/views/BottomTabBar.tsx
+++ b/packages/react-navigation-tabs/src/views/BottomTabBar.tsx
@@ -1,0 +1,580 @@
+import React from 'react';
+import {
+  Animated,
+  TouchableWithoutFeedback,
+  StyleSheet,
+  View,
+  Keyboard,
+  Platform,
+  LayoutChangeEvent,
+} from 'react-native';
+import SafeAreaView from 'react-native-safe-area-view';
+import { ThemeColors, ThemeContext, NavigationRoute } from 'react-navigation';
+
+import CrossFadeIcon from './CrossFadeIcon';
+import withDimensions from '../utils/withDimensions';
+import {
+  BottomTabBarProps,
+  ButtonComponentProps,
+  KeyboardHidesTabBarAnimationConfig,
+  KeyboardAnimationConfig,
+} from '../types';
+
+type State = {
+  layout: { height: number; width: number };
+  keyboard: boolean;
+  visible: Animated.Value;
+};
+
+const majorVersion = parseInt(Platform.Version as string, 10);
+const isIos = Platform.OS === 'ios';
+const isIOS11 = majorVersion >= 11 && isIos;
+
+const DEFAULT_MAX_TAB_ITEM_WIDTH = 125;
+const DEFAULT_KEYBOARD_ANIMATION_CONFIG: KeyboardHidesTabBarAnimationConfig = {
+  show: {
+    animation: 'timing',
+    config: {
+      useNativeDriver: true,
+      duration: 150,
+    },
+  },
+  hide: {
+    animation: 'timing',
+    config: {
+      useNativeDriver: true,
+      duration: 100,
+    },
+  },
+};
+
+class TouchableWithoutFeedbackWrapper extends React.Component<
+  ButtonComponentProps
+> {
+  render() {
+    const {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      route,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      focused,
+      onPress,
+      onLongPress,
+      testID,
+      accessibilityLabel,
+      accessibilityRole,
+      accessibilityStates,
+      ...rest
+    } = this.props;
+
+    return (
+      <TouchableWithoutFeedback
+        onPress={onPress}
+        onLongPress={onLongPress}
+        testID={testID}
+        hitSlop={{ left: 15, right: 15, top: 0, bottom: 5 }}
+        accessibilityLabel={accessibilityLabel}
+        accessibilityRole={accessibilityRole}
+        accessibilityStates={accessibilityStates}
+      >
+        <View {...rest} />
+      </TouchableWithoutFeedback>
+    );
+  }
+}
+
+class TabBarBottom extends React.Component<BottomTabBarProps, State> {
+  static defaultProps = {
+    keyboardHidesTabBar: true,
+    keyboardHidesTabBarAnimationConfig: DEFAULT_KEYBOARD_ANIMATION_CONFIG,
+    activeTintColor: {
+      light: '#007AFF',
+      dark: '#fff',
+    },
+    inactiveTintColor: {
+      light: '#8e8e93',
+      dark: '#7f7f7f',
+    },
+    activeBackgroundColor: 'transparent',
+    inactiveBackgroundColor: 'transparent',
+    showLabel: true,
+    showIcon: true,
+    allowFontScaling: true,
+    adaptive: isIOS11,
+    safeAreaInset: { bottom: 'always', top: 'never' } as React.ComponentProps<
+      typeof SafeAreaView
+    >['forceInset'],
+  };
+
+  // eslint-disable-next-line react/sort-comp
+  static contextType = ThemeContext;
+
+  state = {
+    layout: { height: 0, width: 0 },
+    keyboard: false,
+    visible: new Animated.Value(1),
+  };
+
+  componentDidMount() {
+    if (Platform.OS === 'ios') {
+      Keyboard.addListener('keyboardWillShow', this._handleKeyboardShow);
+      Keyboard.addListener('keyboardWillHide', this._handleKeyboardHide);
+    } else {
+      Keyboard.addListener('keyboardDidShow', this._handleKeyboardShow);
+      Keyboard.addListener('keyboardDidHide', this._handleKeyboardHide);
+    }
+  }
+
+  // @ts-ignore
+  context: 'light' | 'dark';
+
+  _getKeyboardAnimationConfigByType = (
+    type: keyof KeyboardHidesTabBarAnimationConfig
+  ): KeyboardAnimationConfig => {
+    const { keyboardHidesTabBarAnimationConfig } = this.props;
+    const defaultKeyboardAnimationConfig =
+      DEFAULT_KEYBOARD_ANIMATION_CONFIG[type];
+    const keyboardAnimationConfig =
+      (keyboardHidesTabBarAnimationConfig &&
+        keyboardHidesTabBarAnimationConfig[type]) ||
+      defaultKeyboardAnimationConfig;
+
+    // merge config only `timing` animation
+    if (
+      keyboardAnimationConfig &&
+      keyboardAnimationConfig.animation === 'timing'
+    ) {
+      return {
+        ...defaultKeyboardAnimationConfig,
+        ...keyboardAnimationConfig,
+        config: {
+          ...defaultKeyboardAnimationConfig.config,
+          ...keyboardAnimationConfig.config,
+        },
+      };
+    }
+
+    return keyboardAnimationConfig as KeyboardAnimationConfig;
+  };
+
+  _handleKeyboardShow = () => {
+    this.setState({ keyboard: true }, () => {
+      const { animation, config } = this._getKeyboardAnimationConfigByType(
+        'show'
+      );
+      Animated[animation](this.state.visible, {
+        toValue: 0,
+        ...config,
+      }).start();
+    });
+  };
+
+  _handleKeyboardHide = () => {
+    const { animation, config } = this._getKeyboardAnimationConfigByType(
+      'hide'
+    );
+    Animated[animation](this.state.visible, {
+      toValue: 1,
+      ...config,
+    }).start(() => {
+      this.setState({ keyboard: false });
+    });
+  };
+
+  _handleLayout = (e: LayoutChangeEvent) => {
+    const { layout } = this.state;
+    const { height, width } = e.nativeEvent.layout;
+
+    if (height === layout.height && width === layout.width) {
+      return;
+    }
+
+    this.setState({
+      layout: {
+        height,
+        width,
+      },
+    });
+  };
+
+  _getActiveTintColor = () => {
+    let { activeTintColor } = this.props;
+    if (!activeTintColor) {
+      return;
+    } else if (typeof activeTintColor === 'string') {
+      return activeTintColor;
+    }
+
+    return activeTintColor[this.context];
+  };
+
+  _getInactiveTintColor = () => {
+    let { inactiveTintColor } = this.props;
+    if (!inactiveTintColor) {
+      return;
+    } else if (typeof inactiveTintColor === 'string') {
+      return inactiveTintColor;
+    }
+
+    return inactiveTintColor[this.context];
+  };
+
+  _getActiveBackgroundColor = () => {
+    let { activeBackgroundColor } = this.props;
+    if (!activeBackgroundColor) {
+      return;
+    } else if (typeof activeBackgroundColor === 'string') {
+      return activeBackgroundColor;
+    }
+
+    return activeBackgroundColor[this.context];
+  };
+
+  _getInactiveBackgroundColor = () => {
+    let { inactiveBackgroundColor } = this.props;
+    if (!inactiveBackgroundColor) {
+      return;
+    } else if (typeof inactiveBackgroundColor === 'string') {
+      return inactiveBackgroundColor;
+    }
+
+    return inactiveBackgroundColor[this.context];
+  };
+
+  _renderLabel = ({
+    route,
+    focused,
+  }: {
+    route: NavigationRoute;
+    focused: boolean;
+  }) => {
+    const { labelStyle, showLabel, showIcon, allowFontScaling } = this.props;
+
+    if (showLabel === false) {
+      return null;
+    }
+
+    const activeTintColor = this._getActiveTintColor();
+    const inactiveTintColor = this._getInactiveTintColor();
+    const label = this.props.getLabelText({ route });
+    const tintColor = focused ? activeTintColor : inactiveTintColor;
+    const horizontal = this._shouldUseHorizontalLabels();
+
+    if (typeof label === 'string') {
+      return (
+        <Animated.Text
+          numberOfLines={1}
+          style={[
+            styles.label,
+            { color: tintColor },
+            showIcon && horizontal ? styles.labelBeside : styles.labelBeneath,
+            labelStyle,
+          ]}
+          allowFontScaling={allowFontScaling}
+        >
+          {label}
+        </Animated.Text>
+      );
+    }
+
+    if (typeof label === 'function') {
+      return label({
+        focused,
+        tintColor,
+        orientation: horizontal ? 'horizontal' : 'vertical',
+      });
+    }
+
+    return label;
+  };
+
+  _renderIcon = ({
+    route,
+    focused,
+  }: {
+    route: NavigationRoute;
+    focused: boolean;
+  }) => {
+    const { renderIcon, showIcon, showLabel } = this.props;
+
+    if (showIcon === false) {
+      return null;
+    }
+
+    const horizontal = this._shouldUseHorizontalLabels();
+
+    const activeTintColor = this._getActiveTintColor();
+    const inactiveTintColor = this._getInactiveTintColor();
+    const activeOpacity = focused ? 1 : 0;
+    const inactiveOpacity = focused ? 0 : 1;
+
+    return (
+      <CrossFadeIcon
+        route={route}
+        horizontal={horizontal}
+        activeOpacity={activeOpacity}
+        inactiveOpacity={inactiveOpacity}
+        activeTintColor={activeTintColor}
+        inactiveTintColor={inactiveTintColor}
+        renderIcon={renderIcon}
+        style={[
+          styles.iconWithExplicitHeight,
+          showLabel === false && !horizontal && styles.iconWithoutLabel,
+          showLabel !== false && !horizontal && styles.iconWithLabel,
+        ]}
+      />
+    );
+  };
+
+  _shouldUseHorizontalLabels = () => {
+    const { routes } = this.props.navigation.state;
+    const {
+      isLandscape,
+      dimensions,
+      adaptive,
+      tabStyle,
+      labelPosition,
+    } = this.props;
+
+    if (labelPosition) {
+      let position;
+      if (typeof labelPosition === 'string') {
+        position = labelPosition;
+      } else {
+        position = labelPosition({
+          deviceOrientation: isLandscape ? 'horizontal' : 'vertical',
+        });
+      }
+
+      if (position) {
+        return position === 'beside-icon';
+      }
+    }
+
+    if (!adaptive) {
+      return false;
+    }
+
+    // @ts-ignore
+    if (Platform.isPad) {
+      let maxTabItemWidth = DEFAULT_MAX_TAB_ITEM_WIDTH;
+
+      const flattenedStyle = StyleSheet.flatten(tabStyle);
+
+      if (flattenedStyle) {
+        if (typeof flattenedStyle.width === 'number') {
+          maxTabItemWidth = flattenedStyle.width;
+        } else if (typeof flattenedStyle.maxWidth === 'number') {
+          maxTabItemWidth = flattenedStyle.maxWidth;
+        }
+      }
+
+      return routes.length * maxTabItemWidth <= dimensions.width;
+    } else {
+      return isLandscape;
+    }
+  };
+
+  render() {
+    const {
+      navigation,
+      keyboardHidesTabBar,
+      onTabPress,
+      onTabLongPress,
+      safeAreaInset,
+      style,
+      tabStyle,
+    } = this.props;
+
+    const { routes } = navigation.state;
+    const isDark = this.context === 'dark';
+
+    const activeBackgroundColor = this._getActiveBackgroundColor();
+    const inactiveBackgroundColor = this._getInactiveBackgroundColor();
+
+    const {
+      position,
+      top,
+      left = 0,
+      bottom = 0,
+      right = 0,
+      margin,
+      marginTop,
+      marginLeft,
+      marginBottom,
+      marginRight,
+      marginHorizontal,
+      marginVertical,
+      ...innerStyle
+    } = StyleSheet.flatten(style || {});
+
+    const containerStyle = {
+      position,
+      top,
+      left,
+      bottom,
+      right,
+      margin,
+      marginTop,
+      marginLeft,
+      marginBottom,
+      marginRight,
+      marginHorizontal,
+      marginVertical,
+    };
+
+    const tabBarStyle = [
+      styles.tabBar,
+      isDark ? styles.tabBarDark : styles.tabBarLight,
+      // @ts-ignore
+      this._shouldUseHorizontalLabels() && !Platform.isPad
+        ? styles.tabBarCompact
+        : styles.tabBarRegular,
+      innerStyle,
+    ];
+
+    return (
+      <Animated.View
+        style={[
+          styles.container,
+          containerStyle,
+          keyboardHidesTabBar
+            ? {
+                // When the keyboard is shown, slide down the tab bar
+                transform: [
+                  {
+                    translateY: this.state.visible.interpolate({
+                      inputRange: [0, 1],
+                      outputRange: [this.state.layout.height, 0],
+                    }),
+                  },
+                ],
+                // Absolutely position the tab bar so that the content is below it
+                // This is needed to avoid gap at bottom when the tab bar is hidden
+                position: this.state.keyboard ? 'absolute' : position,
+              }
+            : null,
+        ]}
+        pointerEvents={
+          keyboardHidesTabBar && this.state.keyboard ? 'none' : 'auto'
+        }
+        onLayout={this._handleLayout}
+      >
+        <SafeAreaView style={tabBarStyle} forceInset={safeAreaInset}>
+          {routes.map((route, index) => {
+            const focused = index === navigation.state.index;
+            const scene = { route, focused };
+            const accessibilityLabel = this.props.getAccessibilityLabel({
+              route,
+            });
+
+            const accessibilityRole = this.props.getAccessibilityRole({
+              route,
+            });
+
+            const accessibilityStates = this.props.getAccessibilityStates(
+              scene
+            );
+
+            const testID = this.props.getTestID({ route });
+
+            const backgroundColor = focused
+              ? activeBackgroundColor
+              : inactiveBackgroundColor;
+
+            const ButtonComponent =
+              this.props.getButtonComponent({ route }) ||
+              TouchableWithoutFeedbackWrapper;
+
+            return (
+              <ButtonComponent
+                key={route.key}
+                route={route}
+                focused={focused}
+                onPress={() => onTabPress({ route })}
+                onLongPress={() => onTabLongPress({ route })}
+                testID={testID}
+                accessibilityLabel={accessibilityLabel}
+                accessibilityRole={accessibilityRole}
+                accessibilityStates={accessibilityStates}
+                style={[
+                  styles.tab,
+                  { backgroundColor },
+                  this._shouldUseHorizontalLabels()
+                    ? styles.tabLandscape
+                    : styles.tabPortrait,
+                  tabStyle,
+                ]}
+              >
+                {this._renderIcon(scene)}
+                {this._renderLabel(scene)}
+              </ButtonComponent>
+            );
+          })}
+        </SafeAreaView>
+      </Animated.View>
+    );
+  }
+}
+
+const DEFAULT_HEIGHT = 49;
+const COMPACT_HEIGHT = 29;
+
+const styles = StyleSheet.create({
+  tabBar: {
+    borderTopWidth: StyleSheet.hairlineWidth,
+    flexDirection: 'row',
+  },
+  tabBarLight: {
+    backgroundColor: ThemeColors.light.header,
+    borderTopColor: ThemeColors.light.headerBorder,
+  },
+  tabBarDark: {
+    backgroundColor: ThemeColors.dark.header,
+    borderTopColor: ThemeColors.dark.headerBorder,
+  },
+  container: {
+    elevation: 8,
+  },
+  tabBarCompact: {
+    height: COMPACT_HEIGHT,
+  },
+  tabBarRegular: {
+    height: DEFAULT_HEIGHT,
+  },
+  tab: {
+    flex: 1,
+    alignItems: isIos ? 'center' : 'stretch',
+  },
+  tabPortrait: {
+    justifyContent: 'flex-end',
+    flexDirection: 'column',
+  },
+  tabLandscape: {
+    justifyContent: 'center',
+    flexDirection: 'row',
+  },
+  iconWithoutLabel: {
+    flex: 1,
+  },
+  iconWithLabel: {
+    flex: 1,
+  },
+  iconWithExplicitHeight: {
+    // @ts-ignore
+    height: Platform.isPad ? DEFAULT_HEIGHT : COMPACT_HEIGHT,
+  },
+  label: {
+    textAlign: 'center',
+    backgroundColor: 'transparent',
+  },
+  labelBeneath: {
+    fontSize: 11,
+    marginBottom: 1.5,
+  },
+  labelBeside: {
+    fontSize: 12,
+    marginLeft: 20,
+  },
+});
+
+export default withDimensions(TabBarBottom);

--- a/packages/react-navigation-tabs/src/views/CrossFadeIcon.tsx
+++ b/packages/react-navigation-tabs/src/views/CrossFadeIcon.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { View, StyleSheet, StyleProp, ViewStyle } from 'react-native';
+import Animated from 'react-native-reanimated';
+import { NavigationRoute } from 'react-navigation';
+
+type Props = {
+  route: NavigationRoute;
+  horizontal?: boolean;
+  activeOpacity: number;
+  inactiveOpacity: number;
+  activeTintColor?: string;
+  inactiveTintColor?: string;
+  renderIcon: (props: {
+    route: NavigationRoute;
+    focused: boolean;
+    tintColor?: string;
+    horizontal?: boolean;
+  }) => React.ReactNode;
+  style: StyleProp<ViewStyle>;
+};
+
+export default class TabBarIcon extends React.Component<Props> {
+  render() {
+    const {
+      route,
+      activeOpacity,
+      inactiveOpacity,
+      activeTintColor,
+      inactiveTintColor,
+      renderIcon,
+      horizontal,
+      style,
+    } = this.props;
+
+    // We render the icon twice at the same position on top of each other:
+    // active and inactive one, so we can fade between them.
+    return (
+      <View style={style}>
+        <Animated.View style={[styles.icon, { opacity: activeOpacity }]}>
+          {renderIcon({
+            route,
+            focused: true,
+            horizontal,
+            tintColor: activeTintColor,
+          })}
+        </Animated.View>
+        <Animated.View style={[styles.icon, { opacity: inactiveOpacity }]}>
+          {renderIcon({
+            route,
+            focused: false,
+            horizontal,
+            tintColor: inactiveTintColor,
+          })}
+        </Animated.View>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  icon: {
+    // We render the icon twice at the same position on top of each other:
+    // active and inactive one, so we can fade between them:
+    // Cover the whole iconContainer:
+    position: 'absolute',
+    alignSelf: 'center',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '100%',
+    width: '100%',
+    // Workaround for react-native >= 0.54 layout bug
+    minWidth: 25,
+  },
+});

--- a/packages/react-navigation-tabs/src/views/MaterialTopTabBar.tsx
+++ b/packages/react-navigation-tabs/src/views/MaterialTopTabBar.tsx
@@ -1,0 +1,115 @@
+import * as React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { TabBar } from 'react-native-tab-view';
+import Animated from 'react-native-reanimated';
+import { NavigationRoute } from 'react-navigation';
+import { MaterialTabBarProps } from '../types';
+
+type Scene = { route: NavigationRoute; focused: boolean; color: string };
+
+export default class TabBarTop extends React.PureComponent<
+  MaterialTabBarProps
+> {
+  static defaultProps = {
+    activeTintColor: 'rgba(255, 255, 255, 1)',
+    inactiveTintColor: 'rgba(255, 255, 255, 0.7)',
+    showIcon: false,
+    showLabel: true,
+    upperCaseLabel: true,
+    allowFontScaling: true,
+  };
+
+  _renderLabel = ({ route, focused, color }: Scene) => {
+    const {
+      showLabel,
+      upperCaseLabel,
+      labelStyle,
+      allowFontScaling,
+    } = this.props;
+
+    if (showLabel === false) {
+      return null;
+    }
+
+    const label = this.props.getLabelText({ route });
+
+    if (typeof label === 'string') {
+      return (
+        <Animated.Text
+          style={[styles.label, { color }, labelStyle]}
+          allowFontScaling={allowFontScaling}
+        >
+          {upperCaseLabel ? label.toUpperCase() : label}
+        </Animated.Text>
+      );
+    }
+
+    if (typeof label === 'function') {
+      return label({ focused, tintColor: color });
+    }
+
+    return label;
+  };
+
+  _renderIcon = ({ route, focused, color }: Scene) => {
+    const { renderIcon, showIcon, iconStyle } = this.props;
+
+    if (showIcon === false) {
+      return null;
+    }
+
+    return (
+      <View style={[styles.icon, iconStyle]}>
+        {renderIcon({
+          route,
+          focused,
+          tintColor: color,
+        })}
+      </View>
+    );
+  };
+
+  render() {
+    const {
+      navigation,
+      activeTintColor,
+      inactiveTintColor,
+      /* eslint-disable @typescript-eslint/no-unused-vars */
+      renderIcon,
+      getLabelText,
+      allowFontScaling,
+      showLabel,
+      showIcon,
+      upperCaseLabel,
+      tabBarPosition,
+      screenProps,
+      iconStyle,
+      /* eslint-enable @typescript-eslint/no-unused-vars */
+      ...rest
+    } = this.props;
+
+    return (
+      <TabBar
+        {...rest}
+        activeColor={activeTintColor}
+        inactiveColor={inactiveTintColor}
+        navigationState={navigation.state}
+        renderIcon={this._renderIcon}
+        renderLabel={this._renderLabel}
+      />
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  icon: {
+    height: 24,
+    width: 24,
+  },
+  label: {
+    textAlign: 'center',
+    fontSize: 13,
+    margin: 4,
+    backgroundColor: 'transparent',
+  },
+});

--- a/packages/react-navigation-tabs/src/views/ResourceSavingScene.tsx
+++ b/packages/react-navigation-tabs/src/views/ResourceSavingScene.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { Platform, StyleSheet, View } from 'react-native';
+
+// eslint-disable-next-line import/no-unresolved
+import { Screen, screensEnabled } from 'react-native-screens';
+
+type Props = {
+  isVisible: boolean;
+  children: React.ReactNode;
+  style?: any;
+};
+
+const FAR_FAR_AWAY = 3000; // this should be big enough to move the whole view out of its container
+
+export default class ResourceSavingScene extends React.Component<Props> {
+  render() {
+    if (screensEnabled && screensEnabled()) {
+      const { isVisible, ...rest } = this.props;
+      // @ts-ignore
+      return <Screen active={isVisible ? 1 : 0} {...rest} />;
+    }
+
+    const { isVisible, children, style, ...rest } = this.props;
+
+    return (
+      <View
+        style={[styles.container, style, { opacity: isVisible ? 1 : 0 }]}
+        collapsable={false}
+        removeClippedSubviews={
+          // On iOS, set removeClippedSubviews to true only when not focused
+          // This is an workaround for a bug where the clipped view never re-appears
+          Platform.OS === 'ios' ? !isVisible : true
+        }
+        pointerEvents={isVisible ? 'auto' : 'none'}
+        {...rest}
+      >
+        <View style={isVisible ? styles.attached : styles.detached}>
+          {children}
+        </View>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    overflow: 'hidden',
+  },
+  attached: {
+    flex: 1,
+  },
+  detached: {
+    flex: 1,
+    top: FAR_FAR_AWAY,
+  },
+});

--- a/packages/react-navigation-tabs/tsconfig.json
+++ b/packages/react-navigation-tabs/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "react-navigation-tabs": ["./src/index"]
+    },
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react",
+    "lib": ["esnext"],
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "noImplicitUseStrict": false,
+    "noStrictGenericChecks": false,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "esnext"
+  }
+}


### PR DESCRIPTION
# Summary

Closes #52 新增react-navigation-tabs库

## Checklist

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [X] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)
